### PR TITLE
Fixes commas (if per-player-locale) is enabled else uses NumberUtils default Locale for /pay

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/commands/Commandpay.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/commands/Commandpay.java
@@ -17,10 +17,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Commandpay extends EssentialsLoopCommand {
-    private static final BigDecimal THOUSAND = new BigDecimal(1000);
-    private static final BigDecimal MILLION = new BigDecimal(1_000_000);
-    private static final BigDecimal BILLION = new BigDecimal(1_000_000_000);
-    private static final BigDecimal TRILLION = new BigDecimal(1_000_000_000_000L);
 
     public Commandpay() {
         super("pay");
@@ -44,30 +40,12 @@ public class Commandpay extends EssentialsLoopCommand {
             throw new NotEnoughArgumentsException();
         }
 
-        BigDecimal tempAmount = new BigDecimal(sanitizedString);
-        switch (Character.toLowerCase(ogStr.charAt(ogStr.length() - 1))) {
-            case 'k': {
-                tempAmount = tempAmount.multiply(THOUSAND);
-                break;
-            }
-            case 'm': {
-                tempAmount = tempAmount.multiply(MILLION);
-                break;
-            }
-            case 'b': {
-                tempAmount = tempAmount.multiply(BILLION);
-                break;
-            }
-            case 't': {
-                tempAmount = tempAmount.multiply(TRILLION);
-                break;
-            }
-            default: {
-                break;
-            }
+        final BigDecimal amount;
+        if(ess.getSettings().isPerPlayerLocale()){
+            amount = NumberUtil.parseStringToBDecimal(ogStr, user.getPlayerLocale(ess.getPlayerLocaleProvider().getLocale(user.getBase())));
+        } else {
+            amount = NumberUtil.parseStringToBDecimal(ogStr);
         }
-
-        final BigDecimal amount = tempAmount;
 
         if (amount.compareTo(ess.getSettings().getMinimumPayAmount()) < 0) { // Check if amount is less than minimum-pay-amount
             throw new TranslatableException("minimumPayAmount", NumberUtil.displayCurrencyExactly(ess.getSettings().getMinimumPayAmount(), ess));

--- a/Essentials/src/test/java/com/earth2me/essentials/utils/NumberUtilTest.java
+++ b/Essentials/src/test/java/com/earth2me/essentials/utils/NumberUtilTest.java
@@ -1,0 +1,78 @@
+package com.earth2me.essentials.utils;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+
+public class NumberUtilTest {
+
+    @Test
+    public void testStringParseBDecimal() throws ParseException {
+
+        final BigDecimal decimal = NumberUtil.parseStringToBDecimal("10,000,000.5");
+        assertEquals(decimal.toString(), "10000000.5");
+
+        final BigDecimal decimal2 = NumberUtil.parseStringToBDecimal("10.000.000,5");
+        assertNotEquals(decimal2.toString(), "10000000.5");
+
+        final BigDecimal decimal3 = NumberUtil.parseStringToBDecimal("10000000,5");
+        assertNotEquals(decimal3.toString(), "10000000.5");
+
+        final BigDecimal decimal4 = NumberUtil.parseStringToBDecimal("10000000.5");
+        assertEquals(decimal4.toString(), "10000000.5");
+
+        final BigDecimal decimal5 = NumberUtil.parseStringToBDecimal("10000000.50000");
+        assertEquals(decimal5.toString(), "10000000.5");
+
+        final BigDecimal decimal6 = NumberUtil.parseStringToBDecimal(".50000");
+        assertEquals(decimal6.toString(), "0.5");
+
+        final BigDecimal decimal7 = NumberUtil.parseStringToBDecimal("00000.50000");
+        assertEquals(decimal7.toString(), "0.5");
+
+        final BigDecimal decimal8 = NumberUtil.parseStringToBDecimal(",50000");
+        assertEquals(decimal8.toString(), "50000");
+
+        assertThrows(ParseException.class, ()-> {
+            NumberUtil.parseStringToBDecimal("abc");
+        });
+
+        assertThrows(ParseException.class, ()-> {
+            NumberUtil.parseStringToBDecimal("");
+        });
+
+        assertThrows(ParseException.class, ()-> {
+            NumberUtil.parseStringToBDecimal("M");
+        });
+    }
+
+    @Test
+    public void testStringParseBDecimalLocale() throws ParseException {
+
+        final Locale locale = Locale.GERMANY;
+
+        final BigDecimal decimal = NumberUtil.parseStringToBDecimal("10,000,000.5", locale);
+        assertNotEquals(decimal.toString(), "10000000.5");
+
+        final BigDecimal decimal2 = NumberUtil.parseStringToBDecimal("10.000.000,5", locale);
+        assertEquals(decimal2.toString(), "10000000.5");
+
+        final BigDecimal decimal3 = NumberUtil.parseStringToBDecimal("10000000,5", locale);
+        assertEquals(decimal3.toString(), "10000000.5");
+
+        final BigDecimal decimal4 = NumberUtil.parseStringToBDecimal("10000000.5", locale);
+        assertNotEquals(decimal4.toString(), "10000000.5");
+
+        final BigDecimal decimal5 = NumberUtil.parseStringToBDecimal(",5", locale);
+        assertEquals(decimal5.toString(), "0.5");
+
+        final BigDecimal decimal6 = NumberUtil.parseStringToBDecimal(".50000", locale);
+        assertEquals(decimal6.toString(), "50000");
+    }
+}


### PR DESCRIPTION
- **Added locale functionality to /pay command**
- **Added tests for String to BigDecimal parsing & locale specific parsing**

<!--

EssentialsX bug fix submission guide
====================================

NOTE: Failure to fill out this template properly may result in your PR being
      delayed or ignored without warning.

NOTE: Don't type between any arrows in the template, as this text will be
      hidden. This includes this header block and any other explanation text
      blocks.

Want to discuss your PR before submitting it? Join the EssentialsX Development
server: https://discord.gg/CUN7qVb


EssentialsX is GPL
------------------

By contributing to EssentialsX, you agree to license your code under the
GNU General Public License version 3, which can be found at the link below:
https://github.com/EssentialsX/Essentials/blob/2.x/LICENSE


Instructions
------------

If you are submitting a bug fix, please follow the following steps:

1.  Fill out the template in full.
      This includes providing screenshots and a link to the original bug 
      report. If there isn't an existing bug report, we recommend opening a new
      detailed bug report BEFORE opening your PR to fix it, else your PR may be
      delayed or rejected without warning.
      
      You can open a new bug report by following this link:
      https://github.com/EssentialsX/Essentials/issues/new/choose 

2.  When linking logs or config files, do not attach them to the post!
      Copy and paste any logs into https://gist.github.com/, then paste a
      link to them in the relevant parts of the template. Do not use Hastebin
      or Pastebin, as this can cause issues with future reviews.
      
      DO NOT drag logs directly into this text box, as we cannot read these!

3.  If you are fixing a performance issue, please include a link to a
    Timings and/or profiler report, both before and after your PR.

4.  If you are fixing a visual bug, such as in commands, please include
    screenshots so that we can more easily review the proposed fix.
    (You can drag screenshots into the bottom of the editor.)

-->

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "fixes #nnnn" for each issue. 
-->

This PR fixes #2355. 

### Details

**Proposed fix:**    
<!-- Type a description of your proposed fix below this line. -->


*NumberUtils.java* includes PRETTY_LOCALE which uses as default for PRETTY_FORMAT
*NumberUtils.java* includes 2 new methods for parsing Strings to BigDecimals in default locale OR specified locale.
*Commandpay.java* uses those two new methods to parse the String to BigDecimal according to whether per-player-locale is enabled or not
/pay String to BigDecimal parsing moved from *Commandpay.java* to *NumberUtils.java*
Instead of parsing manually with regex, use NumberFormat instead to make sure parsing is done as intended
Regex filtering & empty string checking is still left in *Commandpay.java* to handle wrong inputs from the user

**Environments tested:**    

<!-- Type the OS you have used below. -->
OS: Windows 11

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: java version "21.0.4" 2024-07-16 LTS

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] CraftBukkit/Spigot/Paper 1.12.2
- [ ] CraftBukkit 1.8.8
- [x] Paper 1.19.4


**Demonstration:**    
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

